### PR TITLE
Add SaaSCity

### DIFF
--- a/public/data/tools.json
+++ b/public/data/tools.json
@@ -968,5 +968,33 @@
     "region": "Africa",
     "trending": true,
     "year": 2025
+  },
+  {
+    "id": 43,
+    "name": "SaaSCity",
+    "category": "productivity",
+    "description": "Gamified SaaS directory where every listing becomes a building on a live isometric city map",
+    "rating": 4.5,
+    "users": "New",
+    "pricing": "Freemium",
+    "features": [
+      "Live City Map",
+      "Dofollow Backlink",
+      "Weekly Launches"
+    ],
+    "icon": "Building2",
+    "color": "from-blue-500 to-indigo-600",
+    "demoUrl": "https://saascity.io",
+    "tags": ["Directory", "Launch", "SEO"],
+    "difficulty": "Beginner",
+    "useCases": [
+      "Product launches",
+      "SaaS discovery",
+      "Backlink building"
+    ],
+    "alternatives": ["Product Hunt", "SaaSHub"],
+    "region": "Global",
+    "trending": false,
+    "year": 2026
   }
 ]

--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -968,5 +968,33 @@
     "region": "Africa",
     "trending": true,
     "year": 2025
+  },
+  {
+    "id": 43,
+    "name": "SaaSCity",
+    "category": "productivity",
+    "description": "Gamified SaaS directory where every listing becomes a building on a live isometric city map",
+    "rating": 4.5,
+    "users": "New",
+    "pricing": "Freemium",
+    "features": [
+      "Live City Map",
+      "Dofollow Backlink",
+      "Weekly Launches"
+    ],
+    "icon": "Building2",
+    "color": "from-blue-500 to-indigo-600",
+    "demoUrl": "https://saascity.io",
+    "tags": ["Directory", "Launch", "SEO"],
+    "difficulty": "Beginner",
+    "useCases": [
+      "Product launches",
+      "SaaS discovery",
+      "Backlink building"
+    ],
+    "alternatives": ["Product Hunt", "SaaSHub"],
+    "region": "Global",
+    "trending": false,
+    "year": 2026
   }
 ]


### PR DESCRIPTION
Adds **SaaSCity** to the tools dataset.

- Site: https://saascity.io
- Submit: https://saascity.io/submit
- Gamified SaaS directory where every listing becomes a building on a live isometric city map.
- Domain Rating 46 (Ahrefs), free listing, dofollow, every submission manually reviewed inside 24h.

Happy to adjust the wording or move it if it belongs somewhere else.

`rating` is required by the `Tool` interface — I put a neutral 4.5 and `users: "New"` rather than invent traffic numbers. Change them to whatever you prefer.